### PR TITLE
优化：直接将DedupConsumeStrategy对象提取到成员变量，在DedupConcurrentListener初始化时候实例化，…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.jaskey</groupId>
+    <groupId>com.iflytek</groupId>
     <artifactId>rocketmq-dedup-listener</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <build>
         <plugins>
             <plugin>
@@ -54,7 +54,21 @@
             <version>1.6.4</version>
         </dependency>
     </dependencies>
-
+    <distributionManagement>
+        <!--涉及到权限，需要配置BU/BG的仓库 -->
+        <repository>
+            <id>mvn-releases</id>
+            <url>
+                https://artifacts.iflytek.com/artifactory/stc-mvn-release-private/
+            </url>
+        </repository>
+        <snapshotRepository>
+            <id>mvn-snapshots</id>
+            <url>
+                https://artifacts.iflytek.com/artifactory/stc-mvn-snapshot-private/
+            </url>
+        </snapshotRepository>
+    </distributionManagement>
 
 
 </project>

--- a/src/main/java/com/github/jaskey/rocketmq/core/DedupConfig.java
+++ b/src/main/java/com/github/jaskey/rocketmq/core/DedupConfig.java
@@ -47,6 +47,7 @@ public class DedupConfig {
      */
     private long dedupRecordReserveMinutes = 60 * 24;
 
+    private int degrationTimes = 10000;
 
     //默认拿uniqkey 作为去重的标识
     public static Function<MessageExt, String> defaultDedupMessageKeyFunction = messageExt -> {
@@ -116,5 +117,7 @@ public class DedupConfig {
         this.dedupRecordReserveMinutes = dedupRecordReserveMinutes;
     }
 
-
+    public void setDegrationTimes(int degrationTimes) {
+        this.degrationTimes = degrationTimes;
+    }
 }


### PR DESCRIPTION
…避免每一条消息都重复创建DedupConsumeStrategy对象。

原因：当前设计上DedupConsumeStrategy对象和dedupConfig对象以及DedupConcurrentListener对象是一对一的，本来就没有支持一个消息一个策略，所以没必要每条消息都去创建DedupConsumeStrategy对象